### PR TITLE
Add support for old version of pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pytest-timeouts [![Build Status](https://travis-ci.org/Scony/pytest-timeouts.svg?branch=master)](https://travis-ci.org/Scony/pytest-timeouts)
+# pytest-timeouts [![Build Status](https://travis-ci.org/Scony/pytest-timeouts.svg?branch=master)](https://travis-ci.org/Scony/pytest-timeouts) [![Supported pytest>=3.1.3](https://img.shields.io/badge/pytest-3.1-green.svg)]()
 
 Linux-only Pytest plugin to control durations of various test case execution phases.
 

--- a/pytest_timeouts.py
+++ b/pytest_timeouts.py
@@ -13,6 +13,16 @@ example: "omi", "imo", "i" - ini only
 """
 
 
+@staticmethod
+def get_markers_old_way(item, name):
+    return item.get_marker(name=name)
+
+
+@staticmethod
+def get_markers_new_way(item, name):
+    return item.iter_markers(name=name)
+
+
 @pytest.hookimpl
 def pytest_addoption(parser):
     group = parser.getgroup('timeouts')
@@ -45,6 +55,10 @@ def pytest_addoption(parser):
 @pytest.hookimpl
 def pytest_configure(config):
     assert hasattr(signal, 'SIGALRM')
+    if pytest.__version__ >= '3.6':
+        TimeoutsPlugin.get_markers = get_markers_new_way
+    else:
+        TimeoutsPlugin.get_markers = get_markers_old_way
     config.pluginmanager.register(TimeoutsPlugin(config))
 
 
@@ -142,7 +156,7 @@ class TimeoutsPlugin(object):
         def get_fixture_scope(item):
             return item._fixtureinfo.name2fixturedefs[
                 item._fixtureinfo.names_closure[0]][0].scope
-        markers = item.iter_markers(name=name)
+        markers = TimeoutsPlugin.get_markers(item, name)
         if markers:
             for marker in markers:
                 if marker.args:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='https://github.com/Scony/pytest-timeouts',
     license='MIT',
     install_requires=[
-        'pytest',
+        'pytest>=3.1',
     ],
     py_modules=[
         'pytest_timeouts',

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,14 @@
 addopts = -vv -ra
 
 [tox]
-envlist = py{27,3},
+envlist = py{27,3}-pytest{3,31},
           py{27,3}-codestyle
 
 [testenv]
-deps = pytest
+deps =
+    pytest31: pytest>=3.1,<3.2
+    pytest3: pytest>=3
+
 commands = pytest test_pytest_timeouts.py {posargs}
 
 [testenv:py27-codestyle]


### PR DESCRIPTION
Close #16 

ToDo:
- [x] Add tests for newest and old version of pytest
- [x] Split implementation between older and never version of pytest
- [x] Add implementation for old version of pytest
- [x] Refactor
- [x] Update dependencies for check minimal pytest version
- [x] Update README.md